### PR TITLE
Some Squid Names adjustments according to feedback

### DIFF
--- a/squidnames/frontend/src/App.css
+++ b/squidnames/frontend/src/App.css
@@ -81,11 +81,13 @@ div.question {
   border-color: grey;
 }
 
-.player.revealed.card-blue, .spymaster.actual.card-blue {
+.player.revealed.card-blue,
+.spymaster.actual.card-blue {
   background-color: lightblue;
 }
 
-.player.revealed.card-red, .spymaster.actual.card-red {
+.player.revealed.card-red,
+.spymaster.actual.card-red {
   background-color: #ff9999; /* Lighter red */
 }
 
@@ -93,11 +95,13 @@ div.question {
   background-color: grey;
 }
 
-.player.actual.card-blue, .spymaster.revealed.card-blue {
+.player.actual.card-blue,
+.spymaster.revealed.card-blue {
   background-color: lightskyblue;
 }
 
-.player.actual.card-red, .spymaster.revealed.card-red {
+.player.actual.card-red,
+.spymaster.revealed.card-red {
   background-color: #ff5555; /* Lighter red */
 }
 

--- a/squidnames/frontend/src/App.css
+++ b/squidnames/frontend/src/App.css
@@ -81,23 +81,23 @@ div.question {
   border-color: grey;
 }
 
-.revealed.card-blue {
+.player.revealed.card-blue, .spymaster.actual.card-blue {
   background-color: lightblue;
 }
 
-.revealed.card-red {
-  background-color: #ffaaaa; /* Lighter red */
+.player.revealed.card-red, .spymaster.actual.card-red {
+  background-color: #ff9999; /* Lighter red */
 }
 
 .revealed.card-assassin {
   background-color: grey;
 }
 
-.actual.card-blue {
+.player.actual.card-blue, .spymaster.revealed.card-blue {
   background-color: lightskyblue;
 }
 
-.actual.card-red {
+.player.actual.card-red, .spymaster.revealed.card-red {
   background-color: #ff5555; /* Lighter red */
 }
 
@@ -125,10 +125,6 @@ div.question {
   border-style: dashed;
 }
 
-.spymaster.actual {
-  border-width: 4px;
-}
-
 .top-bar {
   display: flex;
   justify-content: space-between;
@@ -140,6 +136,18 @@ div.question {
 
 .spymasters {
   display: flex;
+}
+
+.spymaster.actual.card-blue {
+  border-color: lightblue;
+}
+
+.spymaster.actual.card-red {
+  border-color: #ff9999; /* Lighter red */
+}
+
+.spymaster.actual.card-neutral {
+  border-color: tan; /* Lighter red */
 }
 
 .score {

--- a/squidnames/frontend/src/App.css
+++ b/squidnames/frontend/src/App.css
@@ -151,7 +151,7 @@ div.question {
 }
 
 .spymaster.actual.card-neutral {
-  border-color: tan; /* Lighter red */
+  border-color: tan;
 }
 
 .score {

--- a/squidnames/frontend/src/components/card.tsx
+++ b/squidnames/frontend/src/components/card.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { CardState, CardStatus, Team } from 'common/common-types';
 
 interface CardProps {
@@ -34,9 +34,24 @@ const Card: React.FC<CardProps> = ({
   let isConfirmable = !isSpymaster && isTentative && playerTeam === activeTurn;
   let reveal = isSpymaster;
 
+  const [buttonDisabled, setButtonDisabled] = useState(true);
+
+  useEffect(() => {
+    if (isConfirmable) {
+      const timer = setTimeout(() => {
+        setButtonDisabled(false);
+      }, 1000);
+      return () => clearTimeout(timer);
+    } else {
+      setButtonDisabled(true);
+    }
+  }, [isConfirmable]);
+
   let classBuilder: Set<string> = new Set(['word-card']);
   if (isSpymaster) {
     classBuilder.add('spymaster');
+  } else {
+    classBuilder.add('player');
   }
   if (isTentative) {
     classBuilder.add('tentative');
@@ -83,7 +98,7 @@ const Card: React.FC<CardProps> = ({
       break;
   }
 
-  if (reveal) {
+  if (reveal && !isActual) {
     classBuilder.add('revealed');
     switch (card.team) {
       case Team.Blue:
@@ -118,7 +133,7 @@ const Card: React.FC<CardProps> = ({
       {card.word}
       {isConfirmable && (
         <div className="card-actions">
-          <button onClick={handleConfirmClick}>Confirm</button>
+          <button onClick={handleConfirmClick} disabled={buttonDisabled}>Confirm</button>
         </div>
       )}
     </div>

--- a/squidnames/frontend/src/components/card.tsx
+++ b/squidnames/frontend/src/components/card.tsx
@@ -133,7 +133,9 @@ const Card: React.FC<CardProps> = ({
       {card.word}
       {isConfirmable && (
         <div className="card-actions">
-          <button onClick={handleConfirmClick} disabled={buttonDisabled}>Confirm</button>
+          <button onClick={handleConfirmClick} disabled={buttonDisabled}>
+            Confirm
+          </button>
         </div>
       )}
     </div>

--- a/squidnames/frontend/src/components/card.tsx
+++ b/squidnames/frontend/src/components/card.tsx
@@ -36,6 +36,8 @@ const Card: React.FC<CardProps> = ({
 
   const [buttonDisabled, setButtonDisabled] = useState(true);
 
+  // Disable the confirm button for a short time after the button is displayed.
+  // Prevents accidentally clicking the button when it suddenly appears due to a teammate.
   useEffect(() => {
     if (isConfirmable) {
       const timer = setTimeout(() => {


### PR DESCRIPTION
Change spymaster view to make to-be-guessed cards colored more prominently than the already-guessed cards.
Make the "Confirm" button disabled for the first second after it appears.